### PR TITLE
Bump to a release version of Junit plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.2-beta-4</version>
+			<version>1.2</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Graphite plugin can't be correctly installed as it depends on a version of the Junit that is not available anymore.